### PR TITLE
Prepare to support single AIU/Spyre card

### DIFF
--- a/fmwork.py
+++ b/fmwork.py
@@ -203,7 +203,7 @@ def show(
     tensor_parallel):
 
     _ign = 0.2
-    _ign = int(max(_ign * len(var.dts), 1))
+    _ign = int(max(_ign * len(var.dts), 1)) if len(var.dts) > 1 else 0
     _rem = var.dts[_ign:]
     _med = med(_rem)
     _itl = 1000.0 * _med / output_size

--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python -u
+#!/usr/bin/env -S python3 -u
 
 import argparse
 import fmwork
@@ -76,6 +76,8 @@ def params():
     parser.add_argument('--debug_outputs', action='store_true')
     parser.add_argument('--trace_outputs', action='store_true')
     parser.add_argument('--stop_itl', type=float)
+    parser.add_argument('-D', '--device',
+        type=str, required=True, choices=['cpu', 'gpu', 'spyre'] )
 
     parser.parse_args(namespace=par)
 
@@ -114,6 +116,7 @@ def llm():
         gpu_memory_utilization       = par.gpu_memory_utilization,
         kv_cache_dtype               = par.kv_cache_dtype,
         max_model_len                = max(var.input_sizes) + max(var.output_sizes),
+        block_size                   = max(var.input_sizes) + max(var.output_sizes),
         model                        = par.model_path,
         quantization                 = par.quantization,
         tensor_parallel_size         = par.tensor_parallel,
@@ -123,6 +126,7 @@ def llm():
         distributed_executor_backend = par.distributed_executor_backend,
         max_num_seqs                 = par.max_num_seqs,
         enable_chunked_prefill       = par.enable_chunked_prefill,
+        device                       = par.device,
     )
 
     t1 = fmwork.time_get()

--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -79,7 +79,8 @@ def params():
     parser.add_argument('--stop_itl', type=float)
     parser.add_argument('-D', '--device',
         type=str, required=True, choices=['cpu', 'gpu', 'spyre'] )
-
+    parser.add_argument('--block_size', type=int, default=None)
+    
     parser.parse_args(namespace=par)
 
     attrs = []
@@ -117,15 +118,15 @@ def llm():
         gpu_memory_utilization       = par.gpu_memory_utilization,
         kv_cache_dtype               = par.kv_cache_dtype,
         max_model_len                = max(var.input_sizes) + max(var.output_sizes),
-        block_size                   = max(var.input_sizes) + max(var.output_sizes),
+        block_size                   = par.block_size,
         model                        = par.model_path,
         quantization                 = par.quantization,
         tensor_parallel_size         = par.tensor_parallel,
         trust_remote_code            = True,
         num_scheduler_steps          = par.num_scheduler_steps,
-        #use_v2_block_manager         = par.use_v2_block_manager,
+        #use_v2_block_manager         = par.use_v2_block_manager, # deprecated
         distributed_executor_backend = par.distributed_executor_backend,
-        max_num_seqs                 = par.max_num_seqs,
+        max_num_seqs                 = min(par.max_num_seqs, max(var.input_sizes) + max(var.output_sizes)),
         enable_chunked_prefill       = par.enable_chunked_prefill,
         device                       = par.device,
     )
@@ -231,7 +232,11 @@ def run(input_size, output_size, batch_size):
     for rep in range(par.reps):
         fmwork.t0()
         outputs = var.llm.generate(**kwargs)
-        #torch.cuda.synchronize()
+        try:
+            torch.cuda.synchronize()
+        except:
+            # will fail on CPU or AIU, so let it go
+            pass
         ret = fmwork.t1(
             rep, par.reps,
             input_size, output_size, batch_size,

--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -23,6 +23,10 @@ def main():
         t1 = fmwork.time_get()
         print(); print('FMWORK DATASET', '%.6f' % (fmwork.time_diff(t1, t0)))
 
+    os.environ["VLLM_SPYRE_WARMUP_PROMPT_LENS"] = par.input_size
+    os.environ["VLLM_SPYRE_WARMUP_NEW_TOKENS"] = par.output_size
+    os.environ['VLLM_SPYRE_WARMUP_BATCH_SIZES'] = par.batch_size
+    
     llm()
     runs()
     done()

--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -231,7 +231,7 @@ def run(input_size, output_size, batch_size):
     for rep in range(par.reps):
         fmwork.t0()
         outputs = var.llm.generate(**kwargs)
-        torch.cuda.synchronize()
+        #torch.cuda.synchronize()
         ret = fmwork.t1(
             rep, par.reps,
             input_size, output_size, batch_size,

--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -5,6 +5,7 @@ import fmwork
 import torch
 import traceback
 import vllm
+import os
 
 class var: pass
 class par: pass
@@ -21,6 +22,10 @@ def main():
             par.model_path)
         t1 = fmwork.time_get()
         print(); print('FMWORK DATASET', '%.6f' % (fmwork.time_diff(t1, t0)))
+
+    os.environ["VLLM_SPYRE_WARMUP_PROMPT_LENS"] = 'var.input_sizes'
+    os.environ["VLLM_SPYRE_WARMUP_NEW_TOKENS"]  = 'var.output_sizes'
+    os.environ['VLLM_SPYRE_WARMUP_BATCH_SIZES'] = 'var.batch_sizes'
 
     llm()
     runs()

--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -23,10 +23,6 @@ def main():
         t1 = fmwork.time_get()
         print(); print('FMWORK DATASET', '%.6f' % (fmwork.time_diff(t1, t0)))
 
-    os.environ["VLLM_SPYRE_WARMUP_PROMPT_LENS"] = 'var.input_sizes'
-    os.environ["VLLM_SPYRE_WARMUP_NEW_TOKENS"]  = 'var.output_sizes'
-    os.environ['VLLM_SPYRE_WARMUP_BATCH_SIZES'] = 'var.batch_sizes'
-
     llm()
     runs()
     done()
@@ -127,7 +123,7 @@ def llm():
         tensor_parallel_size         = par.tensor_parallel,
         trust_remote_code            = True,
         num_scheduler_steps          = par.num_scheduler_steps,
-        use_v2_block_manager         = par.use_v2_block_manager,
+        #use_v2_block_manager         = par.use_v2_block_manager,
         distributed_executor_backend = par.distributed_executor_backend,
         max_num_seqs                 = par.max_num_seqs,
         enable_chunked_prefill       = par.enable_chunked_prefill,

--- a/infer/vllm/runner
+++ b/infer/vllm/runner
@@ -138,7 +138,7 @@ if [[ ${oos_mode} == "split" ]]; then oos_driver=${oo}; else oos_driver=${oos}; 
 if [[ ${bbs_mode} == "split" ]]; then bbs_driver=${bb}; else bbs_driver=${bbs}; fi
 
 cmd="
-${SDIR}/driver.datasets
+${SDIR}/driver
     --id ${btim}/${etim}
     -m   ${mr}/${mm}
     -i   ${iis_driver}


### PR DESCRIPTION
Added args device and block_size to support AIU/Spyre.
Fixed single rep median calculation

Still failing on multi-aiu when `tensor_parallel_size` > 1

Also, since there is no dynamic batching yet, you can't use an array of batch sizes.

Example call:
```
./infer/vllm/driver -m /models/granite-3.1-8b-instruct -i 512 -o 128 -b 1 -t 1 -D spyre -r 20 --block_size 4096
```

Also set the `block_size` so it won't go OOM due to the large context size of 128k of Granite 3.1+ models.