### PR TITLE
Regenerate unique inputs every repetition

### DIFF
--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -224,6 +224,12 @@ def run(input_size, output_size, batch_size):
     fmwork.reset()
 
     for rep in range(par.reps):
+        if not par.dataset_path:
+            kwargs['prompt_token_ids'] = fmwork.input_generator(
+                par.model_path,
+                input_size, batch_size,
+                return_tensors='np'
+            )
         fmwork.t0()
         outputs = var.llm.generate(**kwargs)
         torch.cuda.synchronize()


### PR DESCRIPTION
# Summary
With the release of VLLM 0.8.0, the V1 engine is now the default. With prefix caching now default enabled, we should regenerate inputs on every repetition otherwise we get inflated throughput from the cache hits on the 2nd+ repetitions.
 -

# GitHub Issue(s) to reference

 -

# Reminders
 * [ yes] should this PR noted in the Changelog?
