### PR TITLE
Standardize output structure and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,4 @@
 - Features
    - 
 - Fixes/updates
-   - 
+   - Standardizes output directory structure and parameter configuration in a JSON file

--- a/infer/vllm/runner
+++ b/infer/vllm/runner
@@ -47,17 +47,17 @@ echo
 echo "${bdir}"
 echo
 
-json_object="{"
+paramsjson="{"
 for arg in "$@"
 do
     key=$(echo $arg | cut -d ' ' -f 1)
     value=$(echo $arg | cut -d ' ' -f 2)
-    json_object+="\"$key\":\"$value\","
+    paramsjson+="\"$key\":\"$value\","
 done
 
-json_object="${json_object%,}}"
-formatted_json=$(echo $json_object | jq '.')
-echo "$formatted_json" > ${bdir}/params.json
+paramsjson="${paramsjson%,}}"
+formattedparams=$(echo $paramsjson | jq '.')
+echo "$formattedparams" > ${bdir}/params.json
 
 if [[ ${devs} == auto ]]; then
     tp_1="0:1:2:3:4:5:6:7"

--- a/infer/vllm/runner
+++ b/infer/vllm/runner
@@ -47,17 +47,15 @@ echo
 echo "${bdir}"
 echo
 
-paramsjson="{"
-for arg in "$@"
-do
-    key=$(echo $arg | cut -d ' ' -f 1)
-    value=$(echo $arg | cut -d ' ' -f 2)
-    paramsjson+="\"$key\":\"$value\","
+paramsjson=$(jq "{}" | fromjson)
+
+for ((i=1; i<$#; i+=2)); do
+    key="${!i}"
+    value="${!i+1}"
+    paramsjson=$(jq ".${key} = \"$value\"" "$json_output")
 done
 
-paramsjson="${paramsjson%,}}"
-formattedparams=$(echo $paramsjson | jq '.')
-echo "$formattedparams" > ${bdir}/params.json
+echo "$paramsjson" > ${bdir}/params.json
 
 if [[ ${devs} == auto ]]; then
     tp_1="0:1:2:3:4:5:6:7"

--- a/infer/vllm/runner
+++ b/infer/vllm/runner
@@ -47,15 +47,31 @@ echo
 echo "${bdir}"
 echo
 
-paramsjson=$(jq "{}" | fromjson)
+extraparams=("${@:1}")
+paramsjson=$(jq -n \
+    --arg rdir "$rdir" \
+    --arg mr "$mr" \
+    --arg mms "$mms" \
+    --arg iis "$iis" \
+    --arg oos "$oos" \
+    --arg bbs "$bbs" \
+    --arg devs "$devs" \
+    --arg sdir "$sdir" \
+    --argjson extraparams "$(printf '%s\n' "${extra_params[@]}" | jq -R . | jq -s .)" \
+    '{
+        rdir: $rdir,
+        mr: $mr,
+        mms: $mms,
+        iis: $iis,
+        oos: $oos,
+        bbs: $bbs,
+        devs: $devs,
+        sdir: $sdir,
+        "@": $extraparams
+    }')
 
-for ((i=1; i<$#; i+=2)); do
-    key="${!i}"
-    value="${!i+1}"
-    paramsjson=$(jq ".${key} = \"$value\"" "$json_output")
-done
-
-echo "$paramsjson" > ${bdir}/params.json
+echo "$paramsjson" | jq '.' > ${bdir}/params.json
+echo "$paramsjson" | jq '.'
 
 if [[ ${devs} == auto ]]; then
     tp_1="0:1:2:3:4:5:6:7"

--- a/infer/vllm/runner
+++ b/infer/vllm/runner
@@ -47,16 +47,17 @@ echo
 echo "${bdir}"
 echo
 
-echo "rdir = ${rdir}"               |& tee -a ${bdir}/params
-echo "mr   = ${mr}"                 |& tee -a ${bdir}/params
-echo "mms  = ${mms}"                |& tee -a ${bdir}/params
-echo "iis  = ${iis} ${iis_mode}"    |& tee -a ${bdir}/params
-echo "oos  = ${oos} ${oos_mode}"    |& tee -a ${bdir}/params
-echo "bbs  = ${bbs} ${bbs_mode}"    |& tee -a ${bdir}/params
-echo "devs = ${devs}"               |& tee -a ${bdir}/params
-echo "sdir = ${sdir}"               |& tee -a ${bdir}/params
-echo "@    = ${@}"                  |& tee -a ${bdir}/params
-echo
+json_object="{"
+for arg in "$@"
+do
+    key=$(echo $arg | cut -d ' ' -f 1)
+    value=$(echo $arg | cut -d ' ' -f 2)
+    json_object+="\"$key\":\"$value\","
+done
+
+json_object="${json_object%,}}"
+formatted_json=$(echo $json_object | jq '.')
+echo "$formatted_json" > ${bdir}/params.json
 
 if [[ ${devs} == auto ]]; then
     tp_1="0:1:2:3:4:5:6:7"
@@ -83,12 +84,6 @@ if [[ -z "${devsets}" ]]; then continue; fi
 
 etim="$(date +%Y%m%d-%H%M%S.%N)"
 edir="${bdir}/${etim}"
-edir+="/${mm}"
-edir+="/${tp}"
-edir+="/${ii}"
-edir+="/${oo}"
-edir+="/${bb}"
-edir+="/${sdir}"
 
 mkdir -p ${edir}/utils
 


### PR DESCRIPTION
# Summary

 This PR makes the following changes to runner:

- simplifies the output directory structure so results are now saved in `<user>/<hostname>/<btim>/<etim>` instead of the long directory structure with all the other parameters we were using earlier
- outputs the parameters in `params.json` in `<user>/<hostname>/<btim>` instead of the params text file for easy reading of the file

*note that this introduces jq as a dependency for runner

# GitHub Issue(s) to reference

 - #23 

# Reminders
 * [x] should this PR noted in the Changelog?

