### PR TITLE
Adding python script to process fmwork data and output to a csv file

### DIFF
--- a/infer/vllm/process.py
+++ b/infer/vllm/process.py
@@ -1,2 +1,139 @@
+import os
+import csv
+import sys
+import re
+from datetime import datetime
 
-# reads in JSON params file and log files from runner to generate csv file
+servers = {
+    'css-host-180': 'H100',
+    'css-host-181': 'H100',
+    'css-host-183': 'H100',
+    'css-host-160': 'A100'
+}
+
+def traverse_directory(rdir):
+    subdirs = []
+
+    for root, dirs, files in os.walk(rdir):
+        for dir_name in dirs:
+            subdir_path = os.path.join(root, dir_name)
+           
+            subdir_path = subdir_path.replace(rdir, '').lstrip(os.sep)
+            
+            path_parts = subdir_path.split(os.sep)
+            if len(path_parts) == 4:
+                subdir_path = subdir_path.replace(os.sep, ',')
+                subdirs.append(subdir_path)
+
+    return subdirs
+
+def find_fmwork_gen_lines(subdir, rdir):
+    leaf_dir = os.path.join(rdir, subdir.replace(',', os.sep))
+    exp_log_path = os.path.join(leaf_dir, 'exp.log')
+    fmwork_gen_lines = []
+
+    if os.path.isfile(exp_log_path):
+        with open(exp_log_path, 'r') as file:
+            for line in file:
+                if line.startswith("FMWORK GEN"):
+                    line = line.replace(' ', ',')
+                    fmwork_gen_lines.append(line.strip())
+
+    return fmwork_gen_lines
+
+def find_vllmversion(subdir, rdir):
+    leaf_dir = os.path.join(rdir, subdir.replace(',', os.sep))
+    pip_list_path = os.path.join(leaf_dir, 'utils', 'pip-list')
+    if os.path.exists(pip_list_path):
+        with open(pip_list_path, 'r') as pip_list_file:
+            pip_list_content = pip_list_file.read()
+
+        vllm_line = re.search(r'^vllm\s+(.*)$', pip_list_content, re.MULTILINE)
+        if vllm_line:
+            vllm_parts = vllm_line.group(1).split()
+            vllm_version=f"{'vllm=='}{vllm_parts[0]}"
+
+    return vllm_version
+
+def find_modelandprec(subdir, rdir):
+    leaf_dir = os.path.join(rdir, subdir.replace(',', os.sep))
+    exp_cmd_path = os.path.join(leaf_dir, 'exp.cmd')
+    if os.path.exists(exp_cmd_path):
+        with open(exp_cmd_path, 'r') as exp_cmd_file:
+            exp_cmd_content = exp_cmd_file.read()
+
+        model_precision = re.search(r'-m\s+(\S+)/(\S+)', exp_cmd_content)
+        if model_precision:
+            model, precision = model_precision.groups()
+
+            if precision == "base":
+                precision = "fp16"
+        
+            model_parts = model.rsplit('/', 1)
+            model = model_parts[-1]
+
+    return model,precision
+
+
+def modify_subdir(subdir, fmwork_gen_line):
+    subdir_parts = subdir.split(',')
+    fmwork_gen_parts = fmwork_gen_line.split(',')
+
+    fmwork_gen_parts = fmwork_gen_parts[2:]
+
+    if len(subdir_parts) >= 4 and len(fmwork_gen_parts) > 0:
+        subdir_parts[3] = fmwork_gen_parts[0]
+
+    fmwork_gen_metrics = fmwork_gen_parts[-9:]
+
+    modified_fmwork_gen_line = ','.join(fmwork_gen_metrics)
+
+    date_str = subdir_parts[2][:8]
+    date_obj = datetime.strptime(date_str, '%Y%m%d')
+    year = date_obj.year
+    month = date_obj.month
+
+    if 1 <= month <= 3:
+        quarter = 1
+    elif 4 <= month <= 6:
+        quarter = 2
+    elif 7 <= month <= 9:
+        quarter = 3
+    else:
+        quarter = 4
+
+    nQyear = f"{quarter}Q{year}"
+
+    server_name = subdir_parts[1]
+    gpu_type = servers.get(server_name, 'Unknown')
+
+    fmwork_gen_4th_part = fmwork_gen_parts[4] if len(fmwork_gen_parts) > 2 else ''
+
+    modified_subdir = f"{nQyear},{','.join(subdir_parts)},{gpu_type},{fmwork_gen_4th_part}"
+
+    return modified_subdir, modified_fmwork_gen_line
+
+def write_to_csv(subdirs, rdir, output_file='fmworkdata.csv'):
+    data_parallelism=1
+    with open(output_file, mode='w', newline='') as file:
+        writer = csv.writer(file)
+        header = ['work','user','host','btim','etim','hw','hwc','back','mm','prec','dp','ii','oo','bb','tp','med','ttft','gen','itl','thp']
+        writer.writerow(header)
+        for subdir in subdirs:
+            fmwork_gen_lines = find_fmwork_gen_lines(subdir, rdir)
+            vllm_version = find_vllmversion(subdir, rdir)
+            model,prec = find_modelandprec(subdir, rdir)
+            for line in fmwork_gen_lines:
+                modified_subdir, modified_fmwork_gen_line = modify_subdir(subdir, line)
+                combined_list = modified_subdir.split(',') + [vllm_version, model, prec, data_parallelism] + modified_fmwork_gen_line.split(',')
+                writer.writerow(combined_list)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python process.py <rdir_path>")
+        sys.exit(1)
+
+    rdir = sys.argv[1]
+    subdirs = traverse_directory(rdir)
+    write_to_csv(subdirs, rdir)
+    print(f"FMWORK GEN data in all subdirectories have been written to fmworkdata.csv")

--- a/infer/vllm/process.py
+++ b/infer/vllm/process.py
@@ -107,9 +107,9 @@ def modify_subdir(subdir, fmwork_gen_line):
     server_name = subdir_parts[1]
     gpu_type = servers.get(server_name, 'Unknown')
 
-    fmwork_gen_4th_part = fmwork_gen_parts[4] if len(fmwork_gen_parts) > 2 else ''
+    hwc = fmwork_gen_parts[4] if len(fmwork_gen_parts) > 2 else ''
 
-    modified_subdir = f"{nQyear},{','.join(subdir_parts)},{gpu_type},{fmwork_gen_4th_part}"
+    modified_subdir = f"{nQyear},{','.join(subdir_parts)},{gpu_type},{hwc}"
 
     return modified_subdir, modified_fmwork_gen_line
 


### PR DESCRIPTION
# Summary

 `process.py` takes in `rdir` as an argument, traverses all the subdirectories within rdir, parses fmwork gen data from `exp.log` files, and gathers other relevant data from `exp.cmd` and `pip-list` in a csv file with the following header:
 ```csv
 work,user,host,btim,etim,hw,hwc,back,mm,prec,dp,ii,oo,bb,tp,med,ttft,gen,itl,thp
 ```
 
 You can run `process.py` like this:
 ```shell
python process.py ~/md0/fmwork-runs
```
Here, `~/md0/fmwork-runs` is the same rdir path provided to the `runner` script.

The generated `fmworkdata.csv` file will be easier to read all the data in one place. We will also use this CSV file as the input to a script to insert fmwork data into IBM Lakehouse.

# GitHub Issue(s) to reference
#22 

# Reminders
 * [ ] should this PR noted in the Changelog?
