### PR TITLE
Add warmup parsing to process_direct

### DIFF
--- a/infer/vllm/process
+++ b/infer/vllm/process
@@ -5,11 +5,6 @@ import json
 import os
 import sys
 import traceback
-import re
-
-WARMUP_RE = re.compile(
-    r'init engine \(profile, create kv cache, warmup model\) took ([0-9]*\.?[0-9]+) seconds'
-)
 
 class fmwork:
     class Exception(Exception):
@@ -46,9 +41,8 @@ def process_direct(args):
 
     for line in open(log_driver, errors='ignore'):
         if warmup is None:
-            m = WARMUP_RE.search(line)
-            if m:
-                warmup = float(m.group(1))
+            if 'init engine (profile, create kv cache, warmup model) took' in line:
+                warmup = float(line.split('took ')[1].split(' seconds')[0])
 
         if line.startswith('FMWORK EXP'):
 
@@ -217,4 +211,3 @@ if __name__ == '__main__':
         print('Interrupted.'); sys.exit(2+128)
     except Exception:
         traceback.print_exc(); sys.exit(3)
-

--- a/infer/vllm/process
+++ b/infer/vllm/process
@@ -5,6 +5,11 @@ import json
 import os
 import sys
 import traceback
+import re
+
+WARMUP_RE = re.compile(
+    r'init engine \(profile, create kv cache, warmup model\) took ([0-9]*\.?[0-9]+) seconds'
+)
 
 class fmwork:
     class Exception(Exception):
@@ -30,6 +35,7 @@ def process_direct(args):
         log_driver = os.path.join(args.path, 'driver.log')
     else:
         log_driver = args.path
+    warmup = None
 
     if not os.path.exists(log_driver):
         raise fmwork.Exception(
@@ -38,7 +44,11 @@ def process_direct(args):
     opts = []
     hits = []
 
-    for line in open(log_driver):
+    for line in open(log_driver, errors='ignore'):
+        if warmup is None:
+            m = WARMUP_RE.search(line)
+            if m:
+                warmup = float(m.group(1))
 
         if line.startswith('FMWORK EXP'):
 
@@ -84,7 +94,7 @@ def process_direct(args):
                 'batch'         : batch_size,
                 'tp'            : tp_size,
                 'opts'          : opts,
-                'warmup'        : None,
+                'warmup'        : round(warmup, 3) if warmup is not None else None,
                 'setup'         : setup,
                 'ttft'          : ttft,
                 'itl'           : itl,


### PR DESCRIPTION
# Summary

 - Implement direct warmup line detection in `process`, skipping warmup block parsing when not present.

# GitHub Issue(s) to reference

 -

# Reminders
 * [ ] should this PR noted in the Changelog?
