### PR TITLE
append server.log to runner.log in server mode

### DIFF
--- a/infer/vllm/runner
+++ b/infer/vllm/runner
@@ -245,5 +245,12 @@ fi
 
 echo "time_end   $(date "+%s.%N")" >> ${odir}/runner.log
 
-echo
+# Add server log to runner log if in server mode and server.log exists
+if [[ ${mode} == server ]] && [[ -f ${odir}/server.log ]]; then
+    echo
+    echo "Adding server log to runner log..."
+    echo >> ${odir}/runner.log
+    cat ${odir}/server.log |& tee -a ${odir}/runner.log
+fi
 
+echo

--- a/infer/vllm/runner
+++ b/infer/vllm/runner
@@ -183,6 +183,10 @@ echo "terminating server ..." >> ${odir}/server.log
 kill -2 ${vllm_server_pid}
 kill -2 ${server_pid}
 
+if [[ -f ${odir}/server.log ]]; then
+    cat ${odir}/server.log
+fi
+
 }
 
 # ==============================================================================
@@ -244,13 +248,5 @@ else
 fi
 
 echo "time_end   $(date "+%s.%N")" >> ${odir}/runner.log
-
-# Add server log to runner log if in server mode and server.log exists
-if [[ ${mode} == server ]] && [[ -f ${odir}/server.log ]]; then
-    echo
-    echo "Adding server log to runner log..."
-    echo >> ${odir}/runner.log
-    cat ${odir}/server.log |& tee -a ${odir}/runner.log
-fi
 
 echo


### PR DESCRIPTION
# Summary

 - Add server log to runner log in server mode

    - Append `server.log` contents to `runner.log` at script completion
    - Output is displayed on screen and logged simultaneously
    - Only applies when mode=server and `server.log` exists

# GitHub Issue(s) to reference

 -

# Reminders
 * [ ] should this PR noted in the Changelog?
