### PR TITLE
:sparkles: Add support prometheus metrics and other thp metrics

### DIFF
--- a/infer/vllm/client
+++ b/infer/vllm/client
@@ -79,16 +79,12 @@ vllm bench serve
 
 echo "$(date) -- starting ${instance}"
 
-# Store start time in UTC
-echo "client_time_start:$(date -u "+%s.%N")"
 
 echo        &>> ${odir}/client.log.${instance}
 echo ${cmd} &>> ${odir}/client.log.${instance}
 echo        &>> ${odir}/client.log.${instance}
 eval ${cmd} &>> ${odir}/client.log.${instance}
 
-# Store end time in UTC
-echo "client_time_end:$(date -u "+%s.%N")"
 
 echo "$(date) -- finished ${instance}"
 

--- a/infer/vllm/client
+++ b/infer/vllm/client
@@ -37,12 +37,18 @@ vllm bench serve
     ${args[*]}
 "
 
+# Store start time in UTC
+echo "client_time_start:$(date -u "+%s.%N")"
+
 echo
 env | sort | sed 's/^/FMWORK ENV /'
 echo
 echo ${cmd}
 echo
 eval ${cmd}
+
+# Store end time in UTC
+echo "client_time_end:$(date -u "+%s.%N")"
 
 # multi-runs enabled!
 # -------------------
@@ -73,10 +79,16 @@ vllm bench serve
 
 echo "$(date) -- starting ${instance}"
 
+# Store start time in UTC
+echo "client_time_start:$(date -u "+%s.%N")"
+
 echo        &>> ${odir}/client.log.${instance}
 echo ${cmd} &>> ${odir}/client.log.${instance}
 echo        &>> ${odir}/client.log.${instance}
 eval ${cmd} &>> ${odir}/client.log.${instance}
+
+# Store end time in UTC
+echo "client_time_end:$(date -u "+%s.%N")"
 
 echo "$(date) -- finished ${instance}"
 

--- a/infer/vllm/process
+++ b/infer/vllm/process
@@ -413,44 +413,6 @@ def process_server(args):
             if line.startswith('time_end' ):
                 time_end   = line.strip().split(' ')[-1]
 
-    if args.enable_prom_metrics:
-        if not time_start or not time_end:
-            raise fmwork.Exception(
-                "time_start or time_end are None"
-            )
-
-        start_timestamp = datetime.fromtimestamp(float(time_start), ZoneInfo('UTC'))
-        end_timestamp = datetime.fromtimestamp(float(time_end), ZoneInfo('UTC'))
-        if not RUNNER_POD_NAME:
-            raise fmwork.Exception(
-                "HOSTNAME env variable missing"
-            )
-        # Collect prometheus metrics
-        pod_label_config = f'{{pod="{RUNNER_POD_NAME}", container!=""}}'
-
-
-        for query_fn in PROM_QUERY_METRICS:
-            # NOTE: Time has to be in epoch
-            cpu_metrics = get_cpu_metrics(
-                THANOS_API_URL,
-                pod_label_config,
-                start_timestamp,
-                end_timestamp,
-                query_fn=query_fn
-            )
-            memory_metrics = get_memory_metrics(
-                THANOS_API_URL,
-                pod_label_config,
-                start_timestamp,
-                end_timestamp,
-                query_fn=query_fn
-            )
-            prom_metrics[query_fn.value] = {
-                "cpu": cpu_metrics,
-                "memory": memory_metrics
-            }
-
-
 
     # get opts from server command and client command (if exists)
     server_cmd_content = open(cmd_server).read().strip()
@@ -542,6 +504,8 @@ def process_server(args):
 
     # Only process metrics if we have success data
     if has_success_data:
+        client_start_time = None
+        client_end_time = None
         # process metrics
         try:
             for line in open(log_client):
@@ -570,6 +534,11 @@ def process_server(args):
                 if line.startswith('Request throughput (req/s)'):
                     req_thp  = float(line.strip().split(' ')[-1])
 
+                if line.startswith('client_time_start:'):
+                    client_start_time  = float(line.strip().split(':')[-1])
+
+                if line.startswith('client_time_end:'):
+                    client_end_time  = float(line.strip().split(':')[-1])
 
             # if shapes could not be read, might be using different dataset
             # read values from output instead
@@ -578,6 +547,42 @@ def process_server(args):
                     input_size  = int(total_input  / requests_ok)
                 if not output_size and total_output:
                     output_size = int(total_output / requests_ok)
+
+            if args.enable_prom_metrics:
+                if not client_start_time or not client_end_time:
+                    raise fmwork.Exception(
+                        "client_time_start or client_time_end are None"
+                    )
+
+                start_timestamp = datetime.fromtimestamp(client_start_time, ZoneInfo('UTC'))
+                end_timestamp = datetime.fromtimestamp(client_end_time, ZoneInfo('UTC'))
+                if not RUNNER_POD_NAME:
+                    raise fmwork.Exception(
+                        "HOSTNAME env variable missing"
+                    )
+                # Collect prometheus metrics
+                pod_label_config = f'{{pod="{RUNNER_POD_NAME}", container!=""}}'
+
+                for query_fn in PROM_QUERY_METRICS:
+                    # NOTE: Time has to be in epoch
+                    cpu_metrics = get_cpu_metrics(
+                        THANOS_API_URL,
+                        pod_label_config,
+                        start_timestamp,
+                        end_timestamp,
+                        query_fn=query_fn
+                    )
+                    memory_metrics = get_memory_metrics(
+                        THANOS_API_URL,
+                        pod_label_config,
+                        start_timestamp,
+                        end_timestamp,
+                        query_fn=query_fn
+                    )
+                    prom_metrics[query_fn.value] = {
+                        "cpu": cpu_metrics,
+                        "memory": memory_metrics
+                    }
 
         except Exception as e:
             # If we can't process metrics due to error, set error info

--- a/infer/vllm/process
+++ b/infer/vllm/process
@@ -6,6 +6,24 @@ import os
 import re
 import sys
 import traceback
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from prometheus_metrics import (
+    get_cpu_metrics,
+    get_memory_metrics,
+    QueryFunction,
+    THANOS_API_TOKEN,
+    THANOS_API_URL
+)
+
+
+### CONSTANTS
+STEP = "5m" # Representing query resolution step width
+PROM_QUERY_METRICS = [QueryFunction.AVG, QueryFunction.MAX]
+PODNAME_ENV_VAR_NAME = "HOSTNAME"
+
+RUNNER_POD_NAME = os.getenv(PODNAME_ENV_VAR_NAME)
 
 class fmwork:
     class Exception(Exception):
@@ -15,11 +33,11 @@ def check_error_in_log(log_path):
 
     if not os.path.exists(log_path):
         return None, None
-    
+
     error_patterns = [
         ("OOR", r"terminate called after throwing an instance of 'std::out_of_range'"),
         ("MFS", r"DtException: Must find space in DDR"),
-        ("UMG", r"DtException: Unable to map graph within architecture constraints"), 
+        ("UMG", r"DtException: Unable to map graph within architecture constraints"),
         ("PVF", r"DtException: Program verification failed"),
         ("VMS", r"DtException: Need to find a valid memory space"),
         ("DIR", r"RuntimeError.*DDR init retried"),
@@ -29,7 +47,7 @@ def check_error_in_log(log_path):
         ("REQ", r"assert req_index is not None"),
         ("CGF", r"Failed to compile graphs: compile_graph failed"),
     ]
-    
+
     try:
         content = open(log_path, 'r', errors='ignore').read()
         for error_code, pattern in error_patterns:
@@ -43,17 +61,17 @@ def check_error_in_log(log_path):
                 return error_code, f'{error_code} | "{pattern}"'
     except Exception as e:
         return "READ_ERROR", f'READ_ERROR | "Could not read log file: {str(e)}"'
-    
+
     return None, None
 
 def extract_model_version(parsed_model, input_model):
 
     if not parsed_model or not input_model:
         return None
-    
+
     if parsed_model.startswith(input_model + '/'):
         return parsed_model[len(input_model) + 1:]
-    
+
     return None
 
 def determine_precision(model_name, default_precision):
@@ -66,7 +84,7 @@ def extract_context_length_direct(log_driver):
 
     if not os.path.exists(log_driver):
         return None
-    
+
     try:
         for line in open(log_driver, errors='ignore'):
             if line.startswith('FMWORK ARG') and '--engine:max_model_len@' in line:
@@ -75,14 +93,14 @@ def extract_context_length_direct(log_driver):
                     return int(match.group(1))
     except Exception:
         pass
-    
+
     return None
 
 def extract_context_length_server(cmd_server):
 
     if not os.path.exists(cmd_server):
         return None
-    
+
     try:
         content = open(cmd_server).read()
         match = re.search(r'--max-model-len\s+(\d+)', content)
@@ -90,17 +108,17 @@ def extract_context_length_server(cmd_server):
             return int(match.group(1))
     except Exception:
         pass
-    
+
     return None
 
 def get_server_completion_info(args_path):
 
     cmd_client = os.path.join(args_path, 'client.cmd')
     log_client = os.path.join(args_path, 'client.log')
-    
+
     num_prompts = None
     successful_requests = None
-    
+
     if os.path.exists(cmd_client):
         try:
             content = open(cmd_client, 'r').read()
@@ -109,7 +127,7 @@ def get_server_completion_info(args_path):
                 num_prompts = int(match.group(1))
         except Exception:
             pass
-    
+
     if os.path.exists(log_client):
         try:
             for line in open(log_client, 'r'):
@@ -118,7 +136,7 @@ def get_server_completion_info(args_path):
                     break
         except Exception:
             pass
-    
+
     return num_prompts, successful_requests
 
 def main():
@@ -129,7 +147,13 @@ def main():
     parser.add('--precision',    type=str, default='fp16')
     parser.add('--metadata_id',  type=str)
     parser.add('--model',        type=str, help='Expected model name for version extraction')
+    parser.add('--enable_prom_metrics', action='store_true', help="Enable prometheus metrics collection")
     args = parser.parse_args()
+
+    if args.enable_prom_metrics and not THANOS_API_TOKEN:
+        raise fmwork.Exception(
+            "THANOS_API_TOKEN not set"
+        )
 
     if os.path.isdir(args.path):
         if os.path.exists(os.path.join(args.path, 'server.log')):
@@ -163,7 +187,7 @@ def process_direct(args):
 
     # Check for errors in driver.log
     error_code, error_msg = check_error_in_log(log_driver)
-    
+
     # Determine if execution was successful (has FMWORK GEN entries)
     has_success_data = False
 
@@ -186,20 +210,20 @@ def process_direct(args):
         if line.startswith('FMWORK ARG'):
 
             opts.append(line.strip()[11:])
-            
+
             # Parse FMWORK ARG parameters for direct mode (backup values)
             arg_line = line.strip()[11:]  # Remove "FMWORK ARG "
             parts = arg_line.split()
             if len(parts) >= 2:
                 key = parts[0]
                 val = ' '.join(parts[1:])
-                
+
                 if key == '--batch_sizes':
                     try:
                         batch_size = int(val)
                     except ValueError:
                         pass
-                elif key == '--input_sizes': 
+                elif key == '--input_sizes':
                     try:
                         input_size = int(val)
                     except ValueError:
@@ -216,7 +240,7 @@ def process_direct(args):
                         tp_size = int(val)
                     except ValueError:
                         pass
-                
+
                 # Always check for model_name
                 if key == '--model_name':
                     model_name = val
@@ -251,7 +275,7 @@ def process_direct(args):
                 status = "OK"
             else:
                 status = f"PART_{error_code}"
-                
+
             notes = []
 
             # Apply --model parameter processing after parsing
@@ -304,7 +328,7 @@ def process_direct(args):
             status = "ERR_UNKNOWN"
             if not error_msg:
                 error_msg = "UNKNOWN | \"No success data and no identifiable error\""
-        
+
         # Apply --model parameter processing after parsing
         if args.model:
             model_version = extract_model_version(model_name, args.model)
@@ -312,15 +336,15 @@ def process_direct(args):
         else:
             model_version = None
             final_model_name = model_name
-        
+
         # Determine precision based on model name
         final_precision = determine_precision(model_name, args.precision)
-        
+
         # Determine context length
         context_length = extract_context_length_direct(log_driver)
         if context_length is None and input_size is not None and output_size is not None:
             context_length = input_size + output_size
-        
+
         hits.append({
             'timestamp'     : None,
             'metadata_id'   : args.metadata_id,
@@ -358,13 +382,14 @@ def process_server(args):
     log_client  = os.path.join(args.path, 'client.log')
     log_metrics = os.path.join(args.path, 'metrics.log')
 
+
     # Check required files for server mode
     required_files = [cmd_server, log_server]
     for path in required_files:
         if not os.path.exists(path):
             raise fmwork.Exception(
                 f'Could not find {path}.')
-    
+
     # Optional files for successful runs
     optional_files = [cmd_client, log_client, log_metrics]
 
@@ -377,6 +402,7 @@ def process_server(args):
     model_name = None
     time_start = None
     time_end = None
+    prom_metrics = {}
 
     if os.path.exists(log_runner):
         for line in open(log_runner):
@@ -386,6 +412,45 @@ def process_server(args):
                 time_start = line.strip().split(' ')[-1]
             if line.startswith('time_end' ):
                 time_end   = line.strip().split(' ')[-1]
+
+    if args.enable_prom_metrics:
+        if not time_start or not time_end:
+            raise fmwork.Exception(
+                "time_start or time_end are None"
+            )
+
+        start_timestamp = datetime.fromtimestamp(float(time_start), ZoneInfo('UTC'))
+        end_timestamp = datetime.fromtimestamp(float(time_end), ZoneInfo('UTC'))
+        if not RUNNER_POD_NAME:
+            raise fmwork.Exception(
+                "HOSTNAME env variable missing"
+            )
+        # Collect prometheus metrics
+        pod_label_config = f'{{pod="{RUNNER_POD_NAME}", container!=""}}'
+
+
+        for query_fn in PROM_QUERY_METRICS:
+            # NOTE: Time has to be in epoch
+            cpu_metrics = get_cpu_metrics(
+                THANOS_API_URL,
+                pod_label_config,
+                start_timestamp,
+                end_timestamp,
+                query_fn=query_fn
+            )
+            memory_metrics = get_memory_metrics(
+                THANOS_API_URL,
+                pod_label_config,
+                start_timestamp,
+                end_timestamp,
+                query_fn=query_fn
+            )
+            prom_metrics[query_fn.value] = {
+                "cpu": cpu_metrics,
+                "memory": memory_metrics
+            }
+
+
 
     # get opts from server command and client command (if exists)
     server_cmd_content = open(cmd_server).read().strip()
@@ -420,24 +485,24 @@ def process_server(args):
     warmup_prompt_match = re.search(r'VLLM_SPYRE_WARMUP_PROMPT_LENS=(\d+)', server_cmd_content)
     if warmup_prompt_match:
         input_size = int(warmup_prompt_match.group(1))
-    
+
     warmup_tokens_match = re.search(r'VLLM_SPYRE_WARMUP_NEW_TOKENS=(\d+)', server_cmd_content)
     if warmup_tokens_match:
         output_size = int(warmup_tokens_match.group(1))
-    
+
     warmup_batch_match = re.search(r'VLLM_SPYRE_WARMUP_BATCH_SIZES=(\d+)', server_cmd_content)
     if warmup_batch_match:
         batch_size = int(warmup_batch_match.group(1))
-    
+
     # Extract other server parameters from server.cmd
     max_num_seqs_match = re.search(r'--max-num-seqs\s+(\d+)', server_cmd_content)
     if max_num_seqs_match and batch_size is None:
         batch_size = int(max_num_seqs_match.group(1))
-    
+
     tensor_parallel_match = re.search(r'--tensor-parallel-size\s+(\d+)', server_cmd_content)
     if tensor_parallel_match:
         tp_size = int(tensor_parallel_match.group(1))
-    
+
     # Extract model from server.cmd as backup
     if not model_name:
         model_match = re.search(r'--model\s+(\S+)', server_cmd_content)
@@ -447,15 +512,15 @@ def process_server(args):
     # Extract client parameters from client.cmd if exists
     if os.path.exists(cmd_client):
         client_cmd_content = open(cmd_client).read().strip()
-        
+
         random_input_match = re.search(r'--random-input-len\s+(\d+)', client_cmd_content)
         if random_input_match:
             input_size = int(random_input_match.group(1))
-        
+
         random_output_match = re.search(r'--random-output-len\s+(\d+)', client_cmd_content)
         if random_output_match:
             output_size = int(random_output_match.group(1))
-        
+
         random_range_match = re.search(r'--random-range-ratio\s+([\d.]+)', client_cmd_content)
         if random_range_match:
             range_ratio = float(random_range_match.group(1))
@@ -465,7 +530,8 @@ def process_server(args):
     # Initialize default values for metrics
     ttft = None
     itl = None
-    thp = None
+    thp = None # output token throughput
+    req_thp = None
     requests_ok = None
     total_input = None
     total_output = None
@@ -501,14 +567,18 @@ def process_server(args):
                 if line.startswith('Output token throughput (tok/s)'):
                     thp  = float(line.strip().split(' ')[-1])
 
+                if line.startswith('Request throughput (req/s)'):
+                    req_thp  = float(line.strip().split(' ')[-1])
+
+
             # if shapes could not be read, might be using different dataset
             # read values from output instead
             if requests_ok and requests_ok > 0:
-                if not input_size and total_input:  
+                if not input_size and total_input:
                     input_size  = int(total_input  / requests_ok)
-                if not output_size and total_output: 
+                if not output_size and total_output:
                     output_size = int(total_output / requests_ok)
-                    
+
         except Exception as e:
             # If we can't process metrics due to error, set error info
             if not error_code:
@@ -523,19 +593,19 @@ def process_server(args):
     if has_success_data:
         # Get completion info for server mode
         num_prompts, successful_requests = get_server_completion_info(args.path)
-        
+
         # Check if it's partial execution (two conditions)
         # Condition 1: Error detected in logs
         if error_code is not None:
             is_partial = True
-        
+
         # Condition 2: Incomplete request completion
         if num_prompts is not None and successful_requests is not None:
             notes.append(f"successful_requests:{successful_requests}")
             notes.append(f"num-prompts:{num_prompts}")
             if successful_requests < num_prompts:
                 is_partial = True
-        
+
         # Set status based on partial execution
         if is_partial:
             if error_code is not None:
@@ -588,12 +658,14 @@ def process_server(args):
         'ttft'          : round(ttft, 3) if ttft is not None else None,
         'itl'           : round(itl,  1) if itl is not None else None,
         'thp'           : round(thp,  1) if thp is not None else None,
+        'req_thp'       : round(req_thp, 3) if req_thp is not None else None,
         'mode'          : 'server',
         'batch_mode'    : batch_mode,
         'range_ratio'   : range_ratio,
         'status'        : status,
         'error_msg'     : error_msg,
         'notes'         : notes,
+        'prom_metrics'  : prom_metrics if prom_metrics and args.enable_prom_metrics else None,
     }]
 
     print(json.dumps(hits, indent=4))

--- a/infer/vllm/process
+++ b/infer/vllm/process
@@ -9,21 +9,10 @@ import traceback
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from prometheus_metrics import (
-    get_cpu_metrics,
-    get_memory_metrics,
-    QueryFunction,
-    THANOS_API_TOKEN,
-    THANOS_API_URL
-)
-
 
 ### CONSTANTS
-STEP = "5m" # Representing query resolution step width
-PROM_QUERY_METRICS = [QueryFunction.AVG, QueryFunction.MAX]
 PODNAME_ENV_VAR_NAME = "HOSTNAME"
 
-RUNNER_POD_NAME = os.getenv(PODNAME_ENV_VAR_NAME)
 
 class fmwork:
     class Exception(Exception):
@@ -149,11 +138,6 @@ def main():
     parser.add('--model',        type=str, help='Expected model name for version extraction')
     parser.add('--enable_prom_metrics', action='store_true', help="Enable prometheus metrics collection")
     args = parser.parse_args()
-
-    if args.enable_prom_metrics and not THANOS_API_TOKEN:
-        raise fmwork.Exception(
-            "THANOS_API_TOKEN not set"
-        )
 
     if os.path.isdir(args.path):
         if os.path.exists(os.path.join(args.path, 'server.log')):
@@ -402,7 +386,7 @@ def process_server(args):
     model_name = None
     time_start = None
     time_end = None
-    prom_metrics = {}
+    prom_metrics = None
 
     if os.path.exists(log_runner):
         for line in open(log_runner):
@@ -549,6 +533,27 @@ def process_server(args):
                     output_size = int(total_output / requests_ok)
 
             if args.enable_prom_metrics:
+
+                # import related functions
+                from prometheus_metrics import (
+                    QueryFunction,
+                    THANOS_API_TOKEN,
+                    THANOS_API_URL,
+                    get_cpu_metrics,
+                    get_memory_metrics
+                )
+
+                PROM_QUERY_METRICS = [QueryFunction.AVG, QueryFunction.MAX]
+
+                RUNNER_POD_NAME = os.getenv(PODNAME_ENV_VAR_NAME)
+
+                if not THANOS_API_TOKEN:
+                    raise fmwork.Exception(
+                        "THANOS_API_TOKEN not set"
+                    )
+
+                prom_metrics = {}
+
                 if not client_start_time or not client_end_time:
                     raise fmwork.Exception(
                         "client_time_start or client_time_end are None"

--- a/infer/vllm/prometheus_metrics.py
+++ b/infer/vllm/prometheus_metrics.py
@@ -1,0 +1,268 @@
+"""Script to get cpu and memory metrics from given container running in kube cluster
+
+Setup:
+pip3 install prometheus-api-client
+
+Example command:
+
+python3 prometheus_metrics.py  --pod-name <POD-NAME> --namespace <NAMESPACE> --container-name <CONTAINER-NAME> --start-time 1756333696 --end-time $(date +%s)
+
+"""
+
+# Assisted by watsonx Code Assistant
+
+import argparse
+import os
+import datetime
+from enum import Enum
+from typing import Any, Dict, Optional
+from zoneinfo import ZoneInfo
+
+
+from prometheus_api_client import PrometheusConnect
+
+
+
+#### CONFIGURATIONS
+THANOS_API_TOKEN = os.getenv("THANOS_API_TOKEN", None)
+THANOS_API_URL = os.getenv("THANOS_API_URL", "http://localhost:19090")
+
+
+### CONSTANTS
+STEP = "5m" # Representing query resolution step width
+
+
+class QueryFunction(Enum):
+    AVG = "avg_over_time"
+    MAX = "max_over_time"
+
+
+def get_pod_metrics_at_timestamp(prometheus_url, labels, start_time, end_time, metric_name=None, query_fn=QueryFunction.AVG) -> Dict[str, Any]:
+    """
+    Collects a specific Prometheus metric for a given pod at a specified timestamp.
+
+    Args:
+        prometheus_url (str): The URL of your Prometheus server (e.g., "http://localhost:9090").
+        labels (str): Kubernetes label configuration
+        start_time (datetime): The timestamp at which to query the metric.
+        end_time (datetime): The timestamp at which to query the metric.
+        metric_name (str): The name of the Prometheus metric to query (e.g., "container_cpu_user_seconds_total").
+        query_fn (str): The vector function to be used for querying (default is "avg_over_time").
+
+    Returns:
+        Dict[str, Any]: A dictionary containing the metric data, or None if an error occurs.
+
+    Raises:
+        ValueError: If metric_name is not specified.
+    """
+
+    if metric_name is None:
+        raise ValueError("Metric name must be specified")
+
+    try:
+        headers = {"Authorization": f"Bearer {THANOS_API_TOKEN}"}
+        prom = PrometheusConnect(url=prometheus_url, headers=headers)
+
+        # Construct the query string
+        query = f'{query_fn.value}({metric_name}{labels}[{STEP}])'
+        # print(query)
+
+        # Execute the query
+        result = prom.custom_query_range(query=query, start_time=start_time, end_time=end_time, step=STEP)
+
+        if result:
+            return result  # Return the result as-is
+        else:
+            raise ValueError(f"No data found for metric '{metric_name}' between {start_time} and {end_time}.")
+
+    except Exception as e:
+        raise ValueError(f"Error connecting to Prometheus or querying metrics: {e}")
+
+
+
+def process_results(query_fn, results):
+    """
+    Process results based on the specified query function.
+
+    Args:
+        query_fn (QueryFunction): The type of query function to apply.
+        results (list): The list of numerical results to process.
+
+    Returns:
+        float: The result of the query function applied to the results.
+
+    Raises:
+        ValueError: If the query function is not recognized.
+    """
+    if query_fn == QueryFunction.AVG:
+        return sum(results) / len(results)
+    elif query_fn == QueryFunction.MAX:
+        return max(results)
+    # To be used for python 3.10+
+    # match query_fn:
+    #     case QueryFunction.AVG:
+    #         return sum(results) / len(results)
+    #     case QueryFunction.MAX:
+    #         return max(results)
+
+
+def get_cpu_metrics(prometheus_url: str, pod_label_config: str, start_time, end_time, query_fn=QueryFunction.AVG) -> Optional[dict]:
+    """Fetches CPU metrics for a specified pod in a given namespace from Prometheus and prints the results.
+
+    Args:
+        prometheus_url (str): The URL of the Prometheus server.
+        pod_label_config (str): Kubernetes label configuration
+        start_time (int): The start timestamp for the query in Unix epoch time.
+        end_time (int): The end timestamp for the query in Unix epoch time.
+        query_fn (str, optional): The Prometheus query function. Default is "avg_over_time".
+
+    Returns:
+        Optinal(dict)
+    """
+    METRIC_NAME = "container_cpu_user_seconds_total"
+
+    # Fetch the metric data for the given pod, namespace, and time range
+    metric_data = get_pod_metrics_at_timestamp(prometheus_url, pod_label_config, start_time, end_time, metric_name=METRIC_NAME, query_fn=query_fn)
+
+    metric_collection = None
+    if metric_data:
+
+        cores_used_list = []
+        cores_percent_list = []
+        for result in metric_data:
+            metric_labels = result['metric']
+            time_series = result['values']
+
+            print(f"\tCPU Metrics:")
+
+            for timestamp, value in time_series:
+                # Convert the timestamp to a human-readable format
+                # readable_time = datetime.datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+
+                # Convert the value to a float for calculations
+                cpu_cores_used = float(value)
+                cpu_percentage = cpu_cores_used * 100
+                cores_used_list.append(cpu_cores_used)
+                cores_percent_list.append(cpu_percentage)
+
+            result_cores_used = process_results(query_fn, cores_used_list)
+            result_cores_percentage = process_results(query_fn, cores_percent_list)
+            # NOTE: This will return the last value returned by the metric_data
+            metric_collection = {
+                "cores": round(result_cores_used, 3),
+                "percentage": round(result_cores_percentage, 3)
+            }
+            print(f"\t\tCores: {result_cores_used:.3f}, Percentage: {result_cores_percentage:.3f}%")
+
+        return metric_collection
+
+
+def get_memory_metrics(prometheus_url: str, pod_label_config, start_time, end_time, query_fn=QueryFunction.AVG) -> Optional[dict]:
+    """
+    Fetches time-series data for a given metric from Prometheus for a specific pod and namespace within a time range.
+
+    Args:
+        prometheus_url (str): The URL of the Prometheus server.
+        pod_label_config (str): The name of the pod to retrieve metrics for.
+        start_time (int): The start timestamp for the query in Unix epoch time.
+        end_time (int): The end timestamp for the query in Unix epoch time.
+        metric_name (str): The name of the Prometheus metric to query.
+        query_fn (str): The Prometheus query function.
+
+    Returns:
+        Optional(dict): dictionary containing the memory metrics
+    """
+    # container_memory_working_set_bytes is the amount of memory the container is actively. A container will get killed if it uses
+    # memory exceeding this memory limit.
+    METRIC_NAME = "container_memory_working_set_bytes"
+
+    metric_collection = None
+
+    metric_data = get_pod_metrics_at_timestamp(prometheus_url, pod_label_config, start_time, end_time, metric_name=METRIC_NAME, query_fn=query_fn)
+    if metric_data:
+
+        mem_bytes_list = []
+        mem_mb_list = []
+        mem_gb_list = []
+        for result in metric_data:
+            metric_labels = result['metric']
+            time_series = result['values']
+            print(f"\tMemory Metrics:")
+            for timestamp, value in time_series:
+                readable_time = datetime.datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+                memory_bytes = float(value)
+                memory_mb = memory_bytes / 1024 / 1024
+                memory_gb = memory_mb / 1024
+
+                mem_bytes_list.append(memory_bytes)
+                mem_mb_list.append(memory_mb)
+                mem_gb_list.append(memory_gb)
+
+            result_mem_bytes = process_results(query_fn, mem_bytes_list)
+            result_mem_mb = process_results(query_fn, mem_mb_list)
+            result_mem_gb = process_results(query_fn, mem_gb_list)
+
+            # Store in dict
+            # NOTE: This will return the last value returned by the metric_data
+            # But the query is currently only supposed to have 1 value
+            metric_collection = {
+                "mb": round(result_mem_mb, 3),
+                "gb": round(result_mem_gb, 3)
+            }
+
+            print(f"\t\tBytes: {result_mem_bytes:.3f}, MB: {result_mem_mb:.3f}, GB: {result_mem_gb:.3f}")
+
+        return metric_collection
+
+
+
+
+
+def get_arguments(argparse):
+
+    parser = argparse.ArgumentParser(description="Fetch resource metrics for a Kubernetes pod.")
+
+    parser.add_argument("--pod-name", type=str, required=True, help="Name of the pod")
+    parser.add_argument("--namespace", type=str, required=True, help="Namespace of the pod")
+    parser.add_argument("--container-name", type=str, required=True, help="Name of the container inside the pod")
+    parser.add_argument("--start-time", type=float, required=True, help="Start timestamp in Unix epoch")
+    parser.add_argument("--end-time", type=float, required=True, help="End timestamp in Unix epoch")
+    parser.add_argument("--api-token", type=str, default=None, required=False, help="Api token to access thanos apis")
+    parser.add_argument("--timezone", type=str, default="UTC", required=False, help="Timezone to use to query prometheus")
+
+    return parser.parse_args()
+
+if __name__ == "__main__":
+
+    args = get_arguments(argparse)
+
+    if not args.api_token and not THANOS_API_TOKEN:
+        raise ValueError("API_TOKEN needs to be provided either via env variable or argument")
+
+    if args.api_token:
+        API_TOKEN = args.api_token
+
+    # Configuration
+    pod_name = args.pod_name
+    namespace = args.namespace
+    container_name = args.container_name
+
+    timezone = ZoneInfo(args.timezone)
+
+    print("Timezone used: ", timezone)
+    start_time = datetime.datetime.fromtimestamp(args.start_time, tz=timezone)
+    end_time = datetime.datetime.fromtimestamp(args.end_time, tz=timezone)
+
+    pod_label_config = f'{{namespace="{namespace}", pod="{pod_name}", container="{container_name}"}}'
+
+    query_fns = [QueryFunction.AVG, QueryFunction.MAX]
+
+    for query_fn in query_fns:
+
+        print(f"\nQuery Fn: {query_fn}")
+
+        get_cpu_metrics(THANOS_API_URL, pod_label_config, start_time, end_time, query_fn=query_fn)
+
+        get_memory_metrics(THANOS_API_URL, pod_label_config, start_time, end_time, query_fn=query_fn)
+
+        print("======================================")

--- a/infer/vllm/prometheus_metrics.py
+++ b/infer/vllm/prometheus_metrics.py
@@ -37,7 +37,7 @@ class QueryFunction(Enum):
     MAX = "max_over_time"
 
 
-def get_pod_metrics_at_timestamp(prometheus_url, labels, start_time, end_time, metric_name=None, query_fn=QueryFunction.AVG) -> Dict[str, Any]:
+def get_pod_metrics_at_timestamp(prometheus_url, start_time, end_time, query=None, metric_name=None) -> Dict[str, Any]:
     """
     Collects a specific Prometheus metric for a given pod at a specified timestamp.
 
@@ -56,19 +56,16 @@ def get_pod_metrics_at_timestamp(prometheus_url, labels, start_time, end_time, m
         ValueError: If metric_name is not specified.
     """
 
-    if metric_name is None:
+    if query is None:
         raise ValueError("Metric name must be specified")
 
     try:
         headers = {"Authorization": f"Bearer {THANOS_API_TOKEN}"}
         prom = PrometheusConnect(url=prometheus_url, headers=headers)
 
-        # Construct the query string
-        query = f'{query_fn.value}({metric_name}{labels}[{STEP}])'
-        # print(query)
-
         # Execute the query
         result = prom.custom_query_range(query=query, start_time=start_time, end_time=end_time, step=STEP)
+
 
         if result:
             return result  # Return the result as-is
@@ -119,10 +116,13 @@ def get_cpu_metrics(prometheus_url: str, pod_label_config: str, start_time, end_
     Returns:
         Optinal(dict)
     """
-    METRIC_NAME = "container_cpu_user_seconds_total"
+    METRIC_NAME = "container_cpu_usage_seconds_total"
+
+
+    query = f'rate({METRIC_NAME}{pod_label_config}[{STEP}])'
 
     # Fetch the metric data for the given pod, namespace, and time range
-    metric_data = get_pod_metrics_at_timestamp(prometheus_url, pod_label_config, start_time, end_time, metric_name=METRIC_NAME, query_fn=query_fn)
+    metric_data = get_pod_metrics_at_timestamp(prometheus_url, start_time, end_time, metric_name=METRIC_NAME, query=query)
 
     metric_collection = None
     if metric_data:
@@ -178,7 +178,10 @@ def get_memory_metrics(prometheus_url: str, pod_label_config, start_time, end_ti
 
     metric_collection = None
 
-    metric_data = get_pod_metrics_at_timestamp(prometheus_url, pod_label_config, start_time, end_time, metric_name=METRIC_NAME, query_fn=query_fn)
+    query = f'{query_fn.value}({METRIC_NAME}{pod_label_config}[{STEP}])'
+    # Fetch the metric data for the given pod, namespace, and time range
+    metric_data = get_pod_metrics_at_timestamp(prometheus_url, start_time, end_time, metric_name=METRIC_NAME, query=query)
+
     if metric_data:
 
         mem_bytes_list = []

--- a/infer/vllm/runner
+++ b/infer/vllm/runner
@@ -238,7 +238,7 @@ cd ${wdir}
 
 echo "model_root ${model_root}"    >> ${odir}/runner.log
 echo "model_name ${model_name}"    >> ${odir}/runner.log
-echo "time_start $(date "+%s.%N")" >> ${odir}/runner.log
+echo "time_start $(date -u "+%s.%N")" >> ${odir}/runner.log
 
 if   [[ ${mode} == direct ]]; then run_mode_direct
 elif [[ ${mode} == server ]]; then run_mode_server
@@ -247,6 +247,6 @@ else
     exit 1
 fi
 
-echo "time_end   $(date "+%s.%N")" >> ${odir}/runner.log
+echo "time_end   $(date -u "+%s.%N")" >> ${odir}/runner.log
 
 echo


### PR DESCRIPTION
# Summary

 - Add support for pulling in cpu and memory metrics from prometheus
- Add support for request throughput metric
- Prometheus metrics is an optional feature enabled via `--enable_prom_metrics` flag
- Add dependency: `prometheus-api-client`
- Env variable for thanos / prometheus configuration:
    - `THANOS_API_TOKEN` 
    -  `THANOS_API_URL`

### Test

```
My process command was:
./process --path /path/to/workspace/20250922-234158.782898336 --metadata_id 1 --model $MODEL_NAME --enable_prom_metrics
```

Final output with metrics:
```json
[
    {
        "timestamp": "1758757833.153036500",
        "metadata_id": "1",
        "engine": "fmwork/infer/vllm",
        "model": "ibm-granite/granite-3.3-8b-instruct",
        "model_version": null,
        "precision": "fp16",
        "input": 1024,
        "output": 128,
        "batch": 16,
        "tp": 1,
        "context_length": 3072,
        "opts": [
            "[server] --env VLLM_SPYRE_USE_CB=1",
            "[server] --no-enable-prefix-caching",
            "[server] --max-model-len 3072",
            "[server] --max-num-seqs 16",
            "[server] --tensor-parallel-size 1",
            "[server] --model ibm-granite/granite-3.3-8b-instruct",
            "[client] --env PYTHONUNBUFFERED=1",
            "[client] --dataset-name random",
            "[client] --random-input-len 1024",
            "[client] --random-output-len 128",
            "[client] --num-prompts 16",
            "[client] --model ibm-granite/granite-3.3-8b-instruct",
            "[client] --odir /home/senuser/perf_workspace//20250924-235033.147602097/"
        ],
        "warmup": null,
        "setup": null,
        "ttft": 6.563,
        "itl": 187.6,
        "thp": 50.9,
        "req_thp": 0.44,
        "mode": "server",
        "batch_mode": "continuous",
        "range_ratio": 0.0,
        "status": "OK",
        "error_msg": null,
        "notes": [
            "successful_requests:16",
            "num-prompts:16"
        ],
        "prom_metrics": {
            "avg_over_time": {
                "cpu": {
                    "cores": 1.027,
                    "percentage": 102.728
                },
                "memory": {
                    "mb": 7458.227,
                    "gb": 7.283
                }
            },
            "max_over_time": {
                "cpu": {
                    "cores": 1.027,
                    "percentage": 102.728
                },
                "memory": {
                    "mb": 40565.902,
                    "gb": 39.615
                }
            }
        }
    }
]
```


