### PR TITLE
Add max_model_len and max_num_seqs CLI options to vLLM driver

### DIFF
--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -41,6 +41,8 @@ def setup_args():
     parser.add('--batch_multiplier', type=int, default=1)
     parser.add('--tp_size',          type=int, required=True)
     parser.add('--reps',             type=int, default=5)
+    parser.add('--max_model_len',    type=int, required=True)
+    parser.add('--max_num_seqs',    type=int, required=True)
     args, opts = parser.parse_known_args()
 
     args.model_path = (
@@ -94,6 +96,8 @@ def setup_engine(args):
     engine = vllm.LLM(
         model = args.model_path,
         tensor_parallel_size = args.tp_size,
+        max_model_len=args.max_model_len,
+        max_num_seqs=args.max_num_seqs,
         **args.subs['engine'],
     )
 


### PR DESCRIPTION
# Summary

Add max_model_len and max_num_seqs CLI options to vLLM driver
